### PR TITLE
管理者一覧ページ(roleによって表示変更)

### DIFF
--- a/src/app/Http/Controllers/ClubController.php
+++ b/src/app/Http/Controllers/ClubController.php
@@ -6,8 +6,5 @@ use Illuminate\Http\Request;
 
 class ClubController extends Controller
 {
-    public function index()
-    {
-        return view('club.index');
-    }
+    
 }

--- a/src/app/Http/Controllers/ClubController.php
+++ b/src/app/Http/Controllers/ClubController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ClubController extends Controller
+{
+    public function index()
+    {
+        return view('club.index');
+    }
+}

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -5,22 +5,16 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
+use App\Services\UserService;
 
 class UserController extends Controller
 {
-    public function index()
+    public function index(UserService $userService)
     {
         $user = Auth::user();
         $role = $user->role;
 
-        if ($role == 1) {
-            // 管理者1の場合、同じサークルの管理者のみを取得
-            $managers = User::where('club_id', $user->club_id)->get();
-        } elseif ($role == 2) {
-            // 管理者2の場合、全ての管理者を取得
-            $managers = User::with('club')->get();
-            
-        }
+        $managers = $userService->getManagers($user);
         return view('dashboard', compact('managers', 'role'));
     }
 

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        $role = $user->role;
+
+        if ($role == 1) {
+            // 管理者1の場合、同じサークルの管理者のみを取得
+            $managers = User::where('club_id', $user->club_id)->get();
+        } elseif ($role == 2) {
+            // 管理者2の場合、全ての管理者を取得
+            $managers = User::all();
+        }
+
+        return view('dashboard', compact('managers', 'role'));
+    }
+
+}

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -18,9 +18,9 @@ class UserController extends Controller
             $managers = User::where('club_id', $user->club_id)->get();
         } elseif ($role == 2) {
             // 管理者2の場合、全ての管理者を取得
-            $managers = User::all();
+            $managers = User::with('club')->get();
+            
         }
-
         return view('dashboard', compact('managers', 'role'));
     }
 

--- a/src/app/Models/Club.php
+++ b/src/app/Models/Club.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Club extends Model
+{
+    protected $table = 'club';
+
+    public function users()
+    {
+        return $this->hasMany(User::class, 'club_id');
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -45,4 +45,9 @@ class User extends Authenticatable implements MustVerifyEmailContract
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function club()
+    {
+        return $this->belongsTo(Club::class, 'club_id');
+    }
 }

--- a/src/app/Services/UserService.php
+++ b/src/app/Services/UserService.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Services;
+use App\Models\User;
+
+class UserService
+{
+    public function getManagers($user)
+    {
+        if ($user->role == 1) {
+            return User::where('club_id', $user->club_id)->get();
+        } elseif ($user->role == 2) {
+            return User::with('club')->get();
+        }
+    }
+}

--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -20,7 +20,7 @@
                                     <th scope="col" class="px-6 py-3">
                                         メールアドレス
                                     </th>
-                                    @if ($role == 1)
+                                    @if ($role == 2)
                                     <th scope="col" class="px-6 py-3">
                                         所属サークル
                                     </th>
@@ -36,9 +36,9 @@
                                 <td class="px-6 py-4">
                                 {{ $manager->email }}
                                 </td>
-                                @if ($role == 1)
+                                @if ($role == 2)
                                 <td class="px-6 py-4">
-                                {{ $manager->club_id }}
+                                {{ $manager->club->name ?? 'N/A' }}
                                 </td>
                                 @endif
                             </tr>

--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -9,7 +9,41 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900 dark:text-gray-100">
-                    {{ __("You're logged in!") }}
+
+                    <div class="relative overflow-x-auto">
+                        <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
+                            <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3">
+                                        名前
+                                    </th>
+                                    <th scope="col" class="px-6 py-3">
+                                        メールアドレス
+                                    </th>
+                                    @if ($role == 1)
+                                    <th scope="col" class="px-6 py-3">
+                                        所属サークル
+                                    </th>
+                                    @endif
+                                </tr>
+                            </thead>
+                            <tbody>
+                            @foreach ($managers as $manager)
+                            <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+                                <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                                {{ $manager->name }}
+                                </th>
+                                <td class="px-6 py-4">
+                                {{ $manager->email }}
+                                </td>
+                                @if ($role == 1)
+                                <td class="px-6 py-4">
+                                {{ $manager->club_id }}
+                                </td>
+                                @endif
+                            </tr>
+                            @endforeach
+    
                 </div>
             </div>
         </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -19,7 +19,10 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', [UserController::class, 'index'])->middleware(['auth', 'verified'])->name('dashboard');
+Route::middleware('auth', 'verified')->group(function () {
+    Route::get('/dashboard', [UserController::class, 'index'])->name('dashboard');
+});
+
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -18,9 +19,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', [UserController::class, 'index'])->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
@@ -31,5 +30,6 @@ Route::middleware('auth')->group(function () {
 Route::get('/users', function () {
     return view('introduce.index');
 });
+
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 確認
  - [x] developにプルリクを出していますか？？
  - [x] Reviewerは設定した？
  - [x] Assignに自分を選びました？？
  - [x] 適切なlabelを選択しましたか？
  - [x] Projects選択した？
  - [x] Developmentでissueと紐付けた？
## やったこと

* このプルリクで何をしたのか？(スクショほしい)
  - 管理者１の場合、そのサークルの管理者がテーブルで全員表示される

 -管理者の名前、メールアドレスが表示される
 -管理者２の場合、全てのサークルの管理者がテーブルで全員表示される

- 管理者の名前、メールアドレス、所属サークルが表示される


## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？（してない場合は「してない」に変更）
- 管理者１の場合
<img width="1412" alt="スクリーンショット 2023-12-09 16 47 50" src="https://github.com/kazuki1023/miniHackathon-202312/assets/107550228/0874657f-5158-40b0-9007-ced378d646c6">

- 管理者２の場合
<img width="1412" alt="スクリーンショット 2023-12-09 16 46 48" src="https://github.com/kazuki1023/miniHackathon-202312/assets/107550228/887f533e-d9cc-4d0e-8429-4aa214c96dde">

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、技術的に自分ではできないこと、なんでもどうぞ！）
